### PR TITLE
fix: Image open command assumes posix-compliant shell

### DIFF
--- a/lua/soil/core.lua
+++ b/lua/soil/core.lua
@@ -29,7 +29,7 @@ local function get_image_command(file)
         do return end
     end
     Logger:info(string.format("Image %s.%s generated!", file, settings.image.format))
-    return string.format("%s; echo $?", settings.image.execute_to_open(image_file))
+    return string.format("sh -c '%s; echo $?'", settings.image.execute_to_open(image_file))
 end
 
 local function execute_command(command, error_msg)


### PR DESCRIPTION
When calling `:Soil`, the command being executed assumes that neovim is being executed inside a posix compliant shell.
I'm using the fish shell for example in which the commands in the form of `{open_cmd}; echo $?` is valid.
To fix this issue, I changed the command to explicitly invoke the `sh` command so users of other shells do not experience this problem.