### PR TITLE
Nvim no longer freezes when Soil opens image browser

### DIFF
--- a/lua/soil/core.lua
+++ b/lua/soil/core.lua
@@ -29,7 +29,7 @@ local function get_image_command(file)
         do return end
     end
     Logger:info(string.format("Image %s.%s generated!", file, settings.image.format))
-    return string.format("sh -c '%s; echo $?'", settings.image.execute_to_open(image_file))
+    return string.format("sh -c '%s & disown; echo $?'", settings.image.execute_to_open(image_file))
 end
 
 local function execute_command(command, error_msg)


### PR DESCRIPTION
- added bash's `&` run image viewer process in background
- added  `disown`  to completely detach image viewer from terminal

- modified:   lua/soil/core.lua
- Known issue:  Each time Soil is run, additional image viewer window is opened. 