### PR TITLE
fix(config): add missing comma in nvim-soil lazy setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ use 'javiorfo/nvim-nyctophilia'
         -- When true this offers some kind of online updating (like plantuml web server)
         actions = {
             redraw = false 
-        }
+        },
 
         -- If you want to use Plant UML jar version instead of the installed version
         puml_jar = "/path/to/plantuml.jar",


### PR DESCRIPTION
The missing comma after the `actions` table in the Lua configuration caused a syntax error. This commit adds the missing comma to ensure the table is properly formatted for 