### PR TITLE
Add support for @startuml "filename" and $status in fishshell

### DIFF
--- a/lua/soil/core.lua
+++ b/lua/soil/core.lua
@@ -81,6 +81,11 @@ function M.run()
         local file = check_for_startuml_filename()
         local format = settings.image.format
         local darkmode = settings.image.darkmode and "-darkmode" or ""
+		local shell = os.getenv("SHELL") .. ""
+		local statusOperator = "$?"
+		if string.find(shell, "fish") then
+			statusOperator = "$status"
+		end
 
         Logger:info("Building...")
         if cli_puml ~= 0 then
@@ -90,8 +95,14 @@ function M.run()
             end
             execute_command(puml_command)
         else
-            local puml_command = string.format("java -jar %s %s -t%s %s; echo $?", puml_jar, file_with_extension, format,
-                darkmode)
+            local puml_command = string.format(
+                "java -jar %s %s -t%s %s; echo %s",
+                puml_jar,
+                file_with_extension,
+                format,
+                darkmode,
+                statusOperator
+            )
             if settings.actions.redraw then
                 redraw()
             end

--- a/lua/soil/core.lua
+++ b/lua/soil/core.lua
@@ -47,6 +47,29 @@ local function redraw()
     os.execute(string.format("ps aux | grep -m 1 %s | awk '{print $2}' | xargs kill -9", img))
 end
 
+local function check_for_startuml_filename()
+    -- Get the full path of the current file without extension
+    local current_file = vim.fn.expand("%:p:r")
+
+    -- Open the current file for reading
+    local file = io.open(vim.fn.expand("%:p"), "r")
+    if not file then
+        error("Failed to open file")
+    end
+
+    -- Read the first line of the file
+    local first_line = file:read("*l")
+    file:close()
+
+    -- Check if the first line contains @startuml "filename"
+    local startuml_filename = first_line:match('@startuml%s+"(.-)"')
+    local new_filename = current_file
+    if startuml_filename then
+        new_filename = current_file:gsub("(.-)([a-z-_]+)$", '"%1' .. startuml_filename .. '"')
+    end
+    return new_filename
+end
+
 function M.run()
     if not validate() then return end
 
@@ -55,7 +78,7 @@ function M.run()
 
     if cli_puml ~= 0 or puml_jar then
         local file_with_extension = vim.fn.expand("%:p")
-        local file = vim.fn.expand("%:p:r")
+        local file = check_for_startuml_filename()
         local format = settings.image.format
         local darkmode = settings.image.darkmode and "-darkmode" or ""
 
@@ -81,7 +104,7 @@ function M.run()
 end
 
 function M.open_image()
-    local file = vim.fn.expand("%:p:r")
+    local file = check_for_startuml_filename()
     execute_command(get_image_command(file), "Image not found. Run :Soil command to generate it.")
 end
 


### PR DESCRIPTION
Thanks for a great plugin

I ran into 2 problems when using it however.

1. I use the `@startuml "filename"` feature of Plantuml to specify the filename of the generated image. The current implementation just uses the name of the `.puml` file, but in this PR I've added some code to parse the `@startuml` line to get the custom filename.
2. I use [fishshell](https://fishshell.com/) and it has this quirk that it uses `$status` instead of `$?`. I've added some `$SHELL` detection to handle this.

